### PR TITLE
Correcciones menores a página de Bash

### DIFF
--- a/bash.html
+++ b/bash.html
@@ -58,7 +58,7 @@
 }
 </script>
 
-    
+
   </head>
 
   <body>
@@ -94,13 +94,13 @@
             </li>
             <li class="nav-item">
               <a class="nav-link" href="bash.html">Bash</a>
-            </li>	    	    
+            </li>
             <li class="nav-item">
               <a class="nav-link" href="acerca.html">Acerca</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="rss-feed.xml">RSS</a>
-            </li>	    
+            </li>
           </ul>
         </div>
       </div>
@@ -122,25 +122,25 @@
 	    <p class="card-text">
 	      Este manual ofrece una descripción completa al lenguaje Bash.
 	    </p>
-	    <p class="card-text">	      	
-Bash es el mejor lenguaje para iniciarse en la programación desde una pequeña motivación práctica en el mundo UNIX. Una vez que una persona aprende los comandos básicos suele resultar práctico aprender bucles o condicionales y almacenar ese trabajo en un fichero. Para ese pequeño trabajo Bash es el lenguaje más indicado. Trabajos básicos clásicos en unix como generar backups sencillos suelen realizarse en este lenguaje.
-	    </p>
-	    
 	    <p class="card-text">
-Bash es un lenguaje de programación estructurado para administradores/as de sistemas escrito inicialmente por Brian Fox. Fué generado desde el proyecto GNU para su shell. Si bien hay muchas shell para unix esta es la que viene preinstalada en las distribuciones GNU/Linux más populares como Debian o Ubuntu.
+Bash es el mejor lenguaje para iniciarse en la programación desde una pequeña motivación práctica en el mundo UNIX. Una vez que una persona aprende los comandos básicos suele resultar práctico aprender bucles o condicionales y almacenar ese trabajo en un fichero. Para ese pequeño trabajo Bash es el lenguaje más indicado. Trabajos básicos clásicos en Unix como generar copias de seguridad suelen realizarse en este lenguaje.
+	    </p>
+
+	    <p class="card-text">
+Bash es un lenguaje de programación estructurado para administradores/as de sistemas escrito inicialmente por Brian Fox. Fue generado desde el proyecto GNU para su shell. Si bien hay muchas shell para Unix, esta es la que viene preinstalada en las distribuciones GNU/Linux más populares como Debian o Ubuntu.
 	    </p>
 
 	    <p class="card-text">
 Desde Libremanuals hemos hecho el esfuerzo de traducción de este manual y distribuimos el resultado desde un <a href="https://notabug.org/jorgesumle/bashrefes">repositorio git público</a>. Admitimos las mejoras constructivas que la comunidad considere adecuadas.
 	    </p>
-	    
+
 	    <p class="card-text">
-	      Hemos escrito algunos <a href="https://github.com/davidam/bash-examples">ejemplos bash</a>, para demostrar algunos usos del lenguaje que incentiven la lectura del libro.
+	      Hemos escrito algunos <a href="https://github.com/davidam/bash-examples">ejemplos de Bash</a> para demostrar algunos usos del lenguaje que incentiven la lectura del libro.
 	    </p>
-	    
+
 	    <ul>
 	      <!-- <li>ISBN: </li> -->
-	      <li>Número de Páginas: 183</li>
+	      <li>Número de Páginas: 195</li>
 	      <li><span property="price">15</span>€</li>
 	    </ul>
 
@@ -152,7 +152,7 @@ Desde Libremanuals hemos hecho el esfuerzo de traducción de este manual y distr
 	    <!-- 	<li><a href="https://www.libros.so/libro/una-introduccion-a-r_1081725">UAM</a></li> -->
 	    <!--   </ul> -->
 
-	    
+
           </div>
         </div>
 


### PR DESCRIPTION
- fue no lleva tilde
- Bash y Unix son nombres propios y se escriben en mayúscula
- Usa palabra en español en vez de *backup*
- No especifica si la copia de seguridad es sencilla o compleja
- cambia «ejemplos bash» por ejemplos «de Bash»
- Elimina espacios a final de línea del documento HTML
- Actualiza el número de páginas (el número es aún provisional)